### PR TITLE
autogen.sh fixes

### DIFF
--- a/cctools/autogen.sh
+++ b/cctools/autogen.sh
@@ -8,17 +8,20 @@ if [ $? -eq 0 ]; then
     ../tools/fix_unistd_issue.sh
 fi
 
-mkdir -p m4
-aclocal
-autoconf
-
+# LIBTOOLIZE=libtoolize
 which glibtoolize &>/dev/null
-
 if [ $? -eq 0 ]; then
-    glibtoolize -c -i
+    LIBTOOLIZE=glibtoolize
 else
-    libtoolize -c -i
+    LIBTOOLIZE=libtoolize
 fi
+
+export LIBTOOLIZE
+mkdir -p m4
+
+$LIBTOOLIZE -c -i
+aclocal -I m4
+autoconf
 
 automake -a -c
 


### PR DESCRIPTION
autogen.sh fixes: run libtoolize 'after' creating the m4 directory. run aclocal with '-I m4' switches.
