### PR TITLE
define _GNU_SOURCE for strnlen()

### DIFF
--- a/cctools/ld64/src/3rd/strlcat.c
+++ b/cctools/ld64/src/3rd/strlcat.c
@@ -23,6 +23,10 @@
 
 #ifndef __APPLE__
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1 /* otherwise string.h may hide strnlen() */
+#endif
+
 #include <string.h>
 
 size_t

--- a/cctools/otool/ofile_print.c
+++ b/cctools/otool/ofile_print.c
@@ -201,6 +201,10 @@
 #define __dr6 dr6
 #define __dr7 dr7
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1 /* otherwise string.h may hide strnlen() */
+#endif
+
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>


### PR DESCRIPTION
define _GNU_SOURCE for strnlen(), otherwise string.h may hide its prototype. (seen with glibc-2.8.)
