### PR TITLE
allow for build directory different than source directory

### DIFF
--- a/cctools/ar/Makefile.am
+++ b/cctools/ar/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = ar 
 ar_LDADD =  \
-        $(top_srcdir)/libstuff/libstuff.la
+        $(top_builddir)/libstuff/libstuff.la
 
 ar_CFLAGS = -D__DARWIN_UNIX03 -I$(top_srcdir)/include -I$(top_srcdir)/include/foreign -I$(top_srcdir)/libstuff $(WARNINGS) $(LTO_DEF) $(ENDIAN_FLAG)
 

--- a/cctools/as/Makefile.am
+++ b/cctools/as/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS=arm i386 x86_64 ppc ppc64
 
 bin_PROGRAMS = as 
 as_LDADD =  \
-        $(top_srcdir)/libstuff/libstuff.la
+        $(top_builddir)/libstuff/libstuff.la
 
 as_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/foreign -I$(top_srcdir)/libstuff $(WARNINGS) $(LTO_DEF) -DNeXT_MOD -DASLIBEXECDIR="\"$(ASLIBEXECDIR)/\"" -D__DARWIN_UNIX03 $(ENDIAN_FLAG)
 

--- a/cctools/as/arm/Makefile.am
+++ b/cctools/as/arm/Makefile.am
@@ -1,7 +1,7 @@
 libexec_PROGRAMS = arm-as
 
 arm_as_LDADD =  \
-        $(top_srcdir)/libstuff/libstuff.la
+        $(top_builddir)/libstuff/libstuff.la
 
 arm_as_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/foreign -I$(top_srcdir)/libstuff -I$(top_srcdir)/as $(WARNINGS) $(LTO_DEF) -DNeXT_MOD -DASLIBEXECDIR="\"$(ASLIBEXECDIR)/\"" -D__DARWIN_UNIX03 -DARM $(ENDIAN_FLAG)
 

--- a/cctools/as/i386/Makefile.am
+++ b/cctools/as/i386/Makefile.am
@@ -1,7 +1,7 @@
 libexec_PROGRAMS = i386-as
 
 i386_as_LDADD =  \
-        $(top_srcdir)/libstuff/libstuff.la
+        $(top_builddir)/libstuff/libstuff.la
 
 i386_as_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/foreign -I$(top_srcdir)/libstuff -I$(top_srcdir)/as $(WARNINGS) $(LTO_DEF) -DNeXT_MOD -DASLIBEXECDIR="\"$(ASLIBEXECDIR)/\"" -D__DARWIN_UNIX03  -DI386 -Di486 -Di586 -Di686 -UPPC $(ENDIAN_FLAG)
 

--- a/cctools/as/ppc/Makefile.am
+++ b/cctools/as/ppc/Makefile.am
@@ -1,7 +1,7 @@
 libexec_PROGRAMS = ppc-as
 
 ppc_as_LDADD =  \
-        $(top_srcdir)/libstuff/libstuff.la
+        $(top_builddir)/libstuff/libstuff.la
 
 ppc_as_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/foreign -I$(top_srcdir)/libstuff -I$(top_srcdir)/as $(WARNINGS) $(LTO_DEF) -DNeXT_MOD -DASLIBEXECDIR="\"$(ASLIBEXECDIR)/\"" -D__DARWIN_UNIX03  -DPPC $(ENDIAN_FLAG)
 

--- a/cctools/as/ppc64/Makefile.am
+++ b/cctools/as/ppc64/Makefile.am
@@ -1,7 +1,7 @@
 libexec_PROGRAMS = ppc64-as
 
 ppc64_as_LDADD =  \
-        $(top_srcdir)/libstuff/libstuff.la
+        $(top_builddir)/libstuff/libstuff.la
 
 ppc64_as_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/foreign -I$(top_srcdir)/libstuff -I$(top_srcdir)/as $(WARNINGS) $(LTO_DEF) -DNeXT_MOD -DASLIBEXECDIR="\"$(ASLIBEXECDIR)/\"" -D__DARWIN_UNIX03  -DPPC -DARCH64 $(ENDIAN_FLAG)
 

--- a/cctools/as/x86_64/Makefile.am
+++ b/cctools/as/x86_64/Makefile.am
@@ -1,7 +1,7 @@
 libexec_PROGRAMS = x86_64-as
 
 x86_64_as_LDADD =  \
-        $(top_srcdir)/libstuff/libstuff.la
+        $(top_builddir)/libstuff/libstuff.la
 
 x86_64_as_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/foreign -I$(top_srcdir)/libstuff -I$(top_srcdir)/as $(WARNINGS) $(LTO_DEF) -DNeXT_MOD -DASLIBEXECDIR="\"$(ASLIBEXECDIR)/\"" -D__DARWIN_UNIX03  -DI386 -Di486 -Di586 -Di686 -DARCH64  $(ENDIAN_FLAG)
 

--- a/cctools/ld/Makefile.am
+++ b/cctools/ld/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = ld_classic 
 ld_classic_LDADD =  \
-        $(top_srcdir)/libstuff/libstuff.la   $(UUID_LIB)
+        $(top_builddir)/libstuff/libstuff.la   $(UUID_LIB)
 
 ld_classic_CFLAGS = -D__DARWIN_UNIX03 -I$(top_srcdir)/include -I$(top_srcdir)/include/foreign -I$(top_srcdir)/libstuff $(WARNINGS) $(LTO_DEF) $(ENDIAN_FLAG) -DDEBUG
 

--- a/cctools/ld64/src/ld/Makefile.am
+++ b/cctools/ld64/src/ld/Makefile.am
@@ -2,10 +2,10 @@ SUBDIRS = parsers passes
 
 bin_PROGRAMS = ld
 ld_LDADD =  \
-    $(top_srcdir)/ld64/src/3rd/libhelper.la  \
-    $(top_srcdir)/ld64/src/3rd/BlocksRuntime/libBlocksRuntime.la  \
-	$(top_srcdir)/ld64/src/ld/parsers/libParsers.la \
-	$(top_srcdir)/ld64/src/ld/passes/libPasses.la \
+     $(top_builddir)/ld64/src/3rd/libhelper.la  \
+    $(top_builddir)/ld64/src/3rd/BlocksRuntime/libBlocksRuntime.la  \
+	$(top_builddir)/ld64/src/ld/parsers/libParsers.la \
+	$(top_builddir)/ld64/src/ld/passes/libPasses.la \
 	$(DL_LIB) \
 	$(UUID_LIB) \
 	$(LTO_LIB)

--- a/cctools/ld64/src/ld/parsers/Makefile.am
+++ b/cctools/ld64/src/ld/parsers/Makefile.am
@@ -8,7 +8,7 @@ noinst_HEADERS =  \
 	opaque_section_file.h 
 
 libParsers_la_LIBADD =  \
-	$(top_srcdir)/ld64/src/3rd/libhelper.la
+	 $(top_builddir)/ld64/src/3rd/libhelper.la
 
 libParsers_la_CXXFLAGS =  \
 	-D__DARWIN_UNIX03 \

--- a/cctools/ld64/src/other/Makefile.am
+++ b/cctools/ld64/src/other/Makefile.am
@@ -39,12 +39,12 @@ ObjectDump_SOURCES = \
 	ObjectDump.cpp \
 	$(top_srcdir)/ld64/src/ld/debugline.c 
 ObjectDump_LDADD =  \
-	$(top_srcdir)/ld64/src/ld/parsers/libParsers.la \
+	$(top_builddir)/ld64/src/ld/parsers/libParsers.la \
 	$(LTO_LIB)
 
 
 dyldinfo_SOURCES =  dyldinfo.cpp
 dyldinfo_LDADD =  \
-	$(top_srcdir)/ld64/src/3rd/libhelper.la
+	$(top_builddir)/ld64/src/3rd/libhelper.la
 
 

--- a/cctools/m4/llvm.m4
+++ b/cctools/m4/llvm.m4
@@ -39,7 +39,7 @@ AC_DEFUN([CHECK_LLVM],
                LTO_DEF=-DLTO_SUPPORT
                # DO NOT include the LLVM include dir directly,
                # it may cause the build to fail.
-               `cp -r $LLVM_INCLUDE_DIR/llvm-c/lto.h include/llvm-c/lto.h 2>/dev/null 1>&2`
+               cp -f $LLVM_INCLUDE_DIR/llvm-c/lto.h `dirname ${0}`/include/llvm-c/lto.h
                AC_SUBST([LTO_DEF])
                AC_SUBST([LTO_RPATH])
                AC_SUBST([LTO_LIB]) ])

--- a/cctools/misc/Makefile.am
+++ b/cctools/misc/Makefile.am
@@ -18,7 +18,7 @@ bin_PROGRAMS =  \
 	codesign_allocate
 
 LDADD =  \
-	$(top_srcdir)/libstuff/libstuff.la \
+	$(top_builddir)/libstuff/libstuff.la \
 	$(DL_LIB) \
 	$(LTO_RPATH)
 

--- a/cctools/otool/Makefile.am
+++ b/cctools/otool/Makefile.am
@@ -2,12 +2,12 @@ bin_PROGRAMS = otool
 
 if ISDARWIN
 otool_LDADD = \
-$(top_srcdir)/libstuff/libstuff.la \
+$(top_builddir)/libstuff/libstuff.la \
 $(PTHREAD_FLAGS) $(CXXABI_LIB) $(DL_LIB) -lobjc
 else
 otool_LDADD = \
-$(top_srcdir)/libstuff/libstuff.la \
-$(top_srcdir)/libobjc2/libobjc.la \
+$(top_builddir)/libstuff/libstuff.la \
+$(top_builddir)/libobjc2/libobjc.la \
 $(PTHREAD_FLAGS) $(CXXABI_LIB) $(DL_LIB)
 endif
 


### PR DESCRIPTION
The autotools machinery assumes top_srcdir to be the root of the build directory. This breaks building in different locations, like "build/" subdirectory.