### PR TITLE
Fix build on systems with glibc's qsort_r.

### DIFF
--- a/cctools/ld64/src/3rd/qsort_r.c
+++ b/cctools/ld64/src/3rd/qsort_r.c
@@ -28,7 +28,6 @@
  */
 
 #define I_AM_QSORT_R
-#define qsort_r qsort_r_local
 
 #include <sys/cdefs.h>
 
@@ -36,6 +35,8 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+
+#define qsort_r qsort_r_local
 
 #ifndef __FreeBSD__
 /* flsl.c */


### PR DESCRIPTION
Self explanatory. glibc's qsort_r uses a different signature and is declared in stdlib.h, thus having the `#define qsort_r` in qsort_r.c before including standard headers breaks build.