### PR TITLE
ld: Add --dump-normalized-lib-args flag

### DIFF
--- a/cctools/ld64/src/ld/Options.h
+++ b/cctools/ld64/src/ld/Options.h
@@ -176,6 +176,10 @@ public:
         // Returns true if a previous call to checkFileExists() succeeded.
         // Returns false if the file does not exist of checkFileExists() has never been called.
         bool missing() const { return modTime == -1; }
+
+        // Serialize the file info as a command line argument that would be parsed as the same file
+        // info. Best effort if some attributes cannot be preserved through the round trip.
+        std::vector<std::string> lib_cli_argument() const;
 	};
 
 	struct ExtraSection {
@@ -484,6 +488,7 @@ public:
 	uint8_t						maxDefaultCommonAlign() const { return fMaxDefaultCommonAlign; }
 	bool						hasDataSymbolMoves() const { return !fSymbolsMovesData.empty(); }
 	bool						hasCodeSymbolMoves() const { return !fSymbolsMovesCode.empty(); }
+	bool						dumpNormalizedLibArgs() const { return fDumpNormalizedLibArgs; }
 
 	static uint32_t				parseVersionNumber32(const char*);
 
@@ -796,6 +801,7 @@ private:
 	const char*							fDependencyInfoPath;
 	mutable int							fDependencyFileDescriptor;
 	uint8_t								fMaxDefaultCommonAlign;
+	bool								fDumpNormalizedLibArgs;
 };
 
 

--- a/cctools/ld64/src/ld/ld.cpp
+++ b/cctools/ld64/src/ld/ld.cpp
@@ -49,6 +49,7 @@
 #include <dlfcn.h>
 #include <AvailabilityMacros.h>
 
+#include <iostream>
 #include <string>
 #include <map>
 #include <set>
@@ -1303,6 +1304,14 @@ int main(int argc, const char* argv[])
 		
 		// create object to track command line arguments
 		Options options(argc, argv);
+		if (options.dumpNormalizedLibArgs()) {
+			for (auto info : options.getInputFiles()) {
+				for (auto arg : info.lib_cli_argument()) {
+					std::cout << arg << '\0';
+				}
+			}
+			exit(0);
+		}
 		InternalState state(options);
 		
 		// allow libLTO to be overridden by command line -lto_library


### PR DESCRIPTION
This allows scripts to see how cctools resolves inputs. Args are printed `\0`-separated for easy machine consumption.

Fixes #32; See that issue for a more in-depth explanation of the purpose of this change.

CC @shlevy