### PR TITLE
FIX: wrong libexecdir used so as does not find its assembler

### DIFF
--- a/cctools/as/driver.c
+++ b/cctools/as/driver.c
@@ -386,7 +386,7 @@ char **envp)
 	/*
 	 * If this assembler exist try to run it else print an error message.
 	 */
-	as = makestr(prefix, LIB, arch_name, AS, NULL);
+	as = makestr(LIB, arch_name, AS, NULL);
 	new_argv = allocate((argc + 1) * sizeof(char *));
 	new_argv[0] = as;
 	j = 1;
@@ -408,7 +408,7 @@ char **envp)
 	    else
 		exit(1);
 	}
-	as_local = makestr(prefix, LOCALLIB, arch_name, AS, NULL);
+	as_local = makestr(LOCALLIB, arch_name, AS, NULL);
 	new_argv[0] = as_local;
 	if(access(as_local, F_OK) == 0){
 	    argv[0] = as_local;
@@ -422,7 +422,7 @@ char **envp)
 	arch_flags = get_arch_flags();
 	count = 0;
 	for(i = 0; arch_flags[i].name != NULL; i++){
-	    as = makestr(prefix, LIB, arch_flags[i].name, AS, NULL);
+	    as = makestr(LIB, arch_flags[i].name, AS, NULL);
 	    if(access(as, F_OK) == 0){
 		if(count == 0)
 		    printf("Installed assemblers are:\n");
@@ -430,7 +430,7 @@ char **envp)
 		count++;
 	    }
 	    else{
-		as_local = makestr(prefix, LOCALLIB, arch_flags[i].name, AS,
+		as_local = makestr(LOCALLIB, arch_flags[i].name, AS,
 				   NULL);
 		if(access(as_local, F_OK) == 0){
 		    if(count == 0)

--- a/cctools/as/driver.c
+++ b/cctools/as/driver.c
@@ -29,8 +29,8 @@ int argc,
 char **argv,
 char **envp)
 {
-    const char *LIB = "../libexec/as/";
-    const char *LOCALLIB = "../local/libexec/as/";
+    const char *LIB = ASLIBEXECDIR;
+    const char *LOCALLIB = ASLIBEXECDIR;
     const char *AS = "/as";
 
     int i, j;


### PR DESCRIPTION
if you set a libexecdir via configure, the as tool does not find its assembler.

This is caused by a wrong search-path used. I compared it with the old odcctools which I used before, and found that the define for the directory was not used anymore