### PR TITLE
Port to musl libc

### DIFF
--- a/cctools/ar/archive.c
+++ b/cctools/ar/archive.c
@@ -90,6 +90,10 @@ static char hb[sizeof(HDR) + 1];	/* real header */
 
 int archive_opened_for_writing = 0;
 
+#ifndef DEFFILEMODE
+#define DEFFILEMODE S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH
+#endif
+
 int
 open_archive(mode)
 	int mode;

--- a/cctools/ar/archive.h
+++ b/cctools/ar/archive.h
@@ -61,6 +61,8 @@
  *	@(#)archive.h	8.3 (Berkeley) 4/2/94
  */
 
+#include <sys/types.h>
+
 /* Ar(1) options. */
 #define	AR_A	0x0001
 #define	AR_B	0x0002

--- a/cctools/include/foreign/sys/sysctl.h
+++ b/cctools/include/foreign/sys/sysctl.h
@@ -1,4 +1,4 @@
-#ifndef __CYGWIN__
+#if defined(__APPLE__) || defined(__GLIBC__)
 #include_next <sys/sysctl.h>
 #else
 #ifndef __SYSCTL_H__
@@ -19,4 +19,4 @@ int sysctl(const int *name, u_int namelen, void *oldp,	size_t *oldlenp,
     return -1;
 }
 #endif /* __SYSCTL_H__ */
-#endif /* ! __CYGWIN__ */
+#endif /* __APPLE__ || __GLIBC__ */

--- a/cctools/include/sys/cdefs.h
+++ b/cctools/include/sys/cdefs.h
@@ -1,11 +1,27 @@
+#if defined(__GLIBC__) || defined(__APPLE__)
+
+#include_next <sys/cdefs.h>
+
+#else
+
+#ifdef __cplusplus
+#define __BEGIN_DECLS extern "C" {
+#define __END_DECLS }
+#else
+#define __BEGIN_DECLS
+#define __END_DECLS
+#endif
+
+#define __P(x) x
+
+#endif /* __GLIBC__ || __APPLE__ */
+
+#ifdef __GLIBC__
+
 /*
  * Workaround for a GLIBC bug.
  * https://sourceware.org/bugzilla/show_bug.cgi?id=14952
  */
-
-#include_next <sys/cdefs.h>
-
-#ifdef __GLIBC__
 
 #ifndef __extern_inline
 # define __extern_inline \

--- a/cctools/ld64/src/3rd/helper.c
+++ b/cctools/ld64/src/3rd/helper.c
@@ -36,8 +36,12 @@ void __assert_rtn(const char *func, const char *file, int line, const char *msg)
     __assert(msg, file, line, func);
 #elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__CYGWIN__)
     __assert(msg, line, file);
-#else
+#elif defined(__GLIBC__) || defined(__MINGW32__)
     __assert(msg, file, line);
+#else
+    fprintf(stderr, "Assertion failed: %s (%s: %s: %d)\n", msg, file, func, line);
+    fflush(NULL);
+    abort();
 #endif /* __FreeBSD__ */
 }
 

--- a/cctools/ld64/src/ld/parsers/textstub_dylib_file.cpp
+++ b/cctools/ld64/src/ld/parsers/textstub_dylib_file.cpp
@@ -124,7 +124,7 @@ template <typename A>
 		throw strdup(errorMessage.c_str());
 
 	// unmap file - it is no longer needed.
-	munmap((caddr_t)fileContent, fileLength);
+	munmap((void *)fileContent, fileLength);
 
 	// write out path for -t option
 	if ( logAllFiles )

--- a/cctools/libstuff/dylib_roots.c
+++ b/cctools/libstuff/dylib_roots.c
@@ -28,7 +28,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/param.h>
-#ifndef __OPENSTEP__
+#if defined(__APPLE__) || defined(__GLIBC__) || defined(__MINGW32__)
+#define HAVE_FTS
 #include <fts.h>
 #endif
 #include <sys/errno.h>
@@ -116,7 +117,7 @@ find_dylib_in_root(
 char *install_name,
 const char *root)
 {
-#ifndef __OPENSTEP__
+#ifdef HAVE_FTS
     char *base_name, start[MAXPATHLEN + 1], *image_file_name;
     char const *paths[2];
     FTS *fts;


### PR DESCRIPTION
Mostly make sure not to use a few glibc-isms or `_P` macros for pre-ANSI C compilers.
I should note that cctools' ar/ranlib doesn't work properly when built against musl. I didn't
investigate further because dropping in llvm-ar works just fine. The error you see
with the broken ar is:

```
`x86_64-apple-darwin14-ranlib: archive member: libgcc.a(3) size too large (archive member extends past the end of the file)`
```