### PR TITLE
Add musl-fts as an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Mac OS X, iOS, watchOS (untested) and tvOS (untested)
 SDKs with .tdb stubs (>= Xcode 7) require the TAPI library to be installed.  
 => https://github.com/tpoechtrager/apple-libtapi
 
+musl-libc based systems require the musl-fts library to be installed.
+=> https://github.com/pullmoll/musl-fts
+
 Optional, but recommended:
 
 `llvm-devel`               (For Link Time Optimization Support)  

--- a/cctools/ar/archive.c
+++ b/cctools/ar/archive.c
@@ -90,6 +90,10 @@ static char hb[sizeof(HDR) + 1];	/* real header */
 
 int archive_opened_for_writing = 0;
 
+#ifndef DEFFILEMODE
+#define DEFFILEMODE S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH
+#endif
+
 int
 open_archive(mode)
 	int mode;

--- a/cctools/ar/archive.h
+++ b/cctools/ar/archive.h
@@ -61,6 +61,8 @@
  *	@(#)archive.h	8.3 (Berkeley) 4/2/94
  */
 
+#include <sys/types.h>
+
 /* Ar(1) options. */
 #define	AR_A	0x0001
 #define	AR_B	0x0002

--- a/cctools/configure.ac
+++ b/cctools/configure.ac
@@ -314,6 +314,12 @@ LDFLAGS=$ORIGLDFLAGS
 CHECK_LLVM
 LDFLAGS="$LDFLAGS $LTO_RPATH"
 
+### Check for libfts (musl) ###
+
+AC_CHECK_LIB([fts],[fts_open],[
+  AC_CHECK_HEADERS([fts.h], [FTS_LIB=-lfts])], [])
+AC_SUBST(FTS_LIB)
+
 ### Check for libxar ###
 
 if test "x$LLVM_CONFIG" != "xno"; then

--- a/cctools/include/foreign/sys/sysctl.h
+++ b/cctools/include/foreign/sys/sysctl.h
@@ -1,4 +1,4 @@
-#ifndef __CYGWIN__
+#if defined(__APPLE__) || defined(__GLIBC__)
 #include_next <sys/sysctl.h>
 #else
 #ifndef __SYSCTL_H__
@@ -19,4 +19,4 @@ int sysctl(const int *name, u_int namelen, void *oldp,	size_t *oldlenp,
     return -1;
 }
 #endif /* __SYSCTL_H__ */
-#endif /* ! __CYGWIN__ */
+#endif /* __APPLE__ || __GLIBC__ */

--- a/cctools/include/sys/cdefs.h
+++ b/cctools/include/sys/cdefs.h
@@ -1,11 +1,27 @@
+#if defined(__GLIBC__) || defined(__APPLE__)
+
+#include_next <sys/cdefs.h>
+
+#else
+
+#ifdef __cplusplus
+#define __BEGIN_DECLS extern "C" {
+#define __END_DECLS }
+#else
+#define __BEGIN_DECLS
+#define __END_DECLS
+#endif
+
+#define __P(x) x
+
+#endif /* __GLIBC__ || __APPLE__ */
+
+#ifdef __GLIBC__
+
 /*
  * Workaround for a GLIBC bug.
  * https://sourceware.org/bugzilla/show_bug.cgi?id=14952
  */
-
-#include_next <sys/cdefs.h>
-
-#ifdef __GLIBC__
 
 #ifndef __extern_inline
 # define __extern_inline \

--- a/cctools/ld64/src/3rd/helper.c
+++ b/cctools/ld64/src/3rd/helper.c
@@ -36,8 +36,12 @@ void __assert_rtn(const char *func, const char *file, int line, const char *msg)
     __assert(msg, file, line, func);
 #elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__CYGWIN__)
     __assert(msg, line, file);
-#else
+#elif defined(__GLIBC__) || defined(__MINGW32__)
     __assert(msg, file, line);
+#else
+    fprintf(stderr, "Assertion failed: %s (%s: %s: %d)\n", msg, file, func, line);
+    fflush(NULL);
+    abort();
 #endif /* __FreeBSD__ */
 }
 

--- a/cctools/ld64/src/ld/parsers/textstub_dylib_file.cpp
+++ b/cctools/ld64/src/ld/parsers/textstub_dylib_file.cpp
@@ -124,7 +124,7 @@ template <typename A>
 		throw strdup(errorMessage.c_str());
 
 	// unmap file - it is no longer needed.
-	munmap((caddr_t)fileContent, fileLength);
+	munmap((void *)fileContent, fileLength);
 
 	// write out path for -t option
 	if ( logAllFiles )

--- a/cctools/libstuff/Makefile.am
+++ b/cctools/libstuff/Makefile.am
@@ -2,6 +2,8 @@ noinst_LTLIBRARIES = libstuff.la
 
 libstuff_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/foreign -D__DARWIN_UNIX03 $(WARNINGS) $(LTO_DEF) -DPROGRAM_PREFIX="\"$(PROGRAM_PREFIX)\"" $(ENDIAN_FLAG)
 
+libstuff_la_LDFLAGS = $(FTS_LIB)
+
 libstuff_la_SOURCES =  \
 	allocate.c  \
 	apple_version.c  \

--- a/cctools/libstuff/dylib_roots.c
+++ b/cctools/libstuff/dylib_roots.c
@@ -28,7 +28,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/param.h>
-#ifndef __OPENSTEP__
+#if defined(__APPLE__) || defined(__GLIBC__) || defined(__MINGW32__)
+#define HAVE_FTS
 #include <fts.h>
 #endif
 #include <sys/errno.h>
@@ -116,7 +117,7 @@ find_dylib_in_root(
 char *install_name,
 const char *root)
 {
-#ifndef __OPENSTEP__
+#ifdef HAVE_FTS
     char *base_name, start[MAXPATHLEN + 1], *image_file_name;
     char const *paths[2];
     FTS *fts;


### PR DESCRIPTION
Some parts of cctools fail to compile on musl due to not having `fts.h`

This adds a check to autoconf to use `musl-fts`, available at https://github.com/pullmoll/musl-fts, and includes the commit from PR #36 