### PR TITLE
travis: remove deprecated use of sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
 dist: trusty
-sudo: required
 
 os:
   - linux


### PR DESCRIPTION
Travis has deprecated the use of `sudo` in `travis.yml`. See [this blog post](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) for more details. 
Also: https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure.