### PR TITLE
use `llvm-config --libs` when linking for lto support check

### DIFF
--- a/cctools/m4/llvm.m4
+++ b/cctools/m4/llvm.m4
@@ -28,12 +28,13 @@ AC_DEFUN([CHECK_LLVM],
       if test "x$LLVM_CONFIG" != "xno"; then
         LLVM_INCLUDE_DIR="`${LLVM_CONFIG} --includedir`"
         LLVM_LIB_DIR="`${LLVM_CONFIG} --libdir`"
+        LLVM_LIBS="`${LLVM_CONFIG} --libs`"
 
         ORIGLDFLAGS=$LDFLAGS
-        LDFLAGS="$LDFLAGS -L${LLVM_LIB_DIR}"
+        LDFLAGS="$LDFLAGS -L${LLVM_LIB_DIR} ${LLVM_LIBS}"
 
         AC_CHECK_LIB([LTO],[lto_get_version], [
-          LTO_LIB="-L${LLVM_LIB_DIR} -lLTO"
+          LTO_LIB="-L${LLVM_LIB_DIR} -lLTO ${LLVM_LIBS}"
           if test "x$rpathlink" = "xyes"; then
             LTO_RPATH="-Wl,-rpath,$LLVM_LIB_DIR,--enable-new-dtags"
           fi


### PR DESCRIPTION
Without these libraries included, `config.log` contains messages like:

```
/usr/bin/ld: warning: libLLVM-8.so, needed by /home/froydnj/.mozbuild/clang/lib/libLTO.so, not found (try using -rpath or -rpath-link)
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::DiagnosticHandler::isAnyRemarkEnabled() const@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::generic_parser_base::printGenericOptionDiff(llvm::cl::Option const&, llvm::cl::GenericOptionValue const&, llvm::cl::GenericOptionValue const&, unsigned long) const@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeARMTargetMC@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::compile_to_file(char const**, bool, bool, bool, bool)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::Option::setArgStr(llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::MemoryBuffer::getFile(llvm::Twine const&, long, bool, bool)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::report_bad_alloc_error(char const*, bool)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeX86Disassembler@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeARMDisassembler@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::opt<bool, false, llvm::cl::parser<bool> >@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::parser<char>@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::compile(bool, bool, bool, bool)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::StringMapImpl::LookupBucketFor(llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::StringMapImpl::RehashTable(unsigned int)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::isBitcodeContainingObjCCategory(llvm::MemoryBufferRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::GeneralCategory@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::opt<int, false, llvm::cl::parser<int> >@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::isThinLTO()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeX86Target@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::report_fatal_error(char const*, bool)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::ParseCommandLineOptions(int, char const* const*, llvm::StringRef, llvm::raw_ostream*, char const*)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::SmallVectorBase::grow_pod(void*, unsigned long, unsigned long)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::createFromOpenFile(llvm::LLVMContext&, int, llvm::StringRef, unsigned long, llvm::TargetOptions const&)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::opt<unsigned int, false, llvm::cl::parser<unsigned int> >@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeAArch64AsmPrinter@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::Module::~Module()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::LTOCodeGenerator(llvm::LLVMContext&)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::AddLiteralOption(llvm::cl::Option&, llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::setDebugInfo(lto_debug_model)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::MCTargetOptions::MCTargetOptions()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::opt<char, false, llvm::cl::parser<char> >@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::parser<int>@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::generic_parser_base::getOptionWidth(llvm::cl::Option const&) const@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::ThinLTOCodeGenerator::addModule(llvm::StringRef, llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeARMAsmParser@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::parseCodeGenDebugOptions()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::alias@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::isBitcodeForTarget(llvm::MemoryBuffer*, llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::GenericOptionValue::anchor()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::setTargetOptions(llvm::TargetOptions const&)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::writeMergedModules(llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LLVMContext::LLVMContext()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::Option::anchor()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::basic_parser_impl::printOptionInfo(llvm::cl::Option const&, unsigned long) const@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeX86AsmPrinter@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::raw_string_ostream@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LLVMContext::setDiagnosticHandler(std::unique_ptr<llvm::DiagnosticHandler, std::default_delete<llvm::DiagnosticHandler> >&&, bool)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::setOptLevel(unsigned int)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::Option::error(llvm::Twine const&, llvm::StringRef, llvm::raw_ostream&)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::createInLocalContext(std::unique_ptr<llvm::LLVMContext, std::default_delete<llvm::LLVMContext> >, void const*, unsigned long, llvm::TargetOptions const&, llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeAArch64Target@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::opt<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, false, llvm::cl::parser<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::SmallPtrSetImplBase::CopyFrom(llvm::SmallPtrSetImplBase const&)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::ThinLTOCodeGenerator::preserveSymbol(llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::~LTOModule()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::isBitcodeFile(void const*, unsigned long)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::ThinLTOCodeGenerator::run()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::addModule(llvm::LTOModule*)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::raw_string_ostream::~raw_string_ostream()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::isBitcodeFile(llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeX86TargetMC@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::setCodeGenDebugOptions(llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeARMTargetInfo@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::parser<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::makeBuffer(void const*, unsigned long, llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::errs()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::parser<unsigned int>@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeAArch64AsmParser@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::~LTOCodeGenerator()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::Option::addArgument()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeAArch64Disassembler@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::parser<bool>@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::Option::addOccurrence(unsigned int, llvm::StringRef, llvm::StringRef, bool)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::DiagnosticHandler::isAnalysisRemarkEnabled(llvm::StringRef) const@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeAArch64TargetInfo@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeAArch64TargetMC@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::DiagnosticHandler::isMissedOptRemarkEnabled(llvm::StringRef) const@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::createFromBuffer(llvm::LLVMContext&, void const*, unsigned long, llvm::TargetOptions const&, llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeX86AsmParser@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::ThinLTOCodeGenerator::crossReferenceSymbol(llvm::StringRef)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::Option@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::optimize(bool, bool, bool, bool)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::DiagnosticPrinterRawOStream@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::basic_parser_impl::getOptionWidth(llvm::cl::Option const&) const@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeARMTarget@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::getVersionString()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::errorToErrorCodeAndEmitErrors(llvm::LLVMContext&, llvm::Error)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeX86TargetInfo@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::createFromOpenFileSlice(llvm::LLVMContext&, int, llvm::StringRef, unsigned long, long, llvm::TargetOptions const&)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LLVMContext::~LLVMContext()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::compileOptimized()@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::setDiagnosticHandler(void (*)(lto_codegen_diagnostic_severity_t, char const*, void*), void*)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOCodeGenerator::setModule(std::unique_ptr<llvm::LTOModule, std::default_delete<llvm::LTOModule> >)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::DiagnosticHandler::isPassedOptRemarkEnabled(llvm::StringRef) const@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::cl::generic_parser_base::printOptionInfo(llvm::cl::Option const&, unsigned long) const@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `LLVMInitializeARMAsmPrinter@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::LTOModule::createFromFile(llvm::LLVMContext&, llvm::StringRef, llvm::TargetOptions const&)@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `vtable for llvm::cl::OptionValue<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >@LLVM_8'
/home/froydnj/.mozbuild/clang/lib/libLTO.so: undefined reference to `llvm::raw_ostream::write(unsigned char)@LLVM_8'
clang-8: error: linker command failed with exit code 1 (use -v to see invocation)
```

which makes it somewhat difficult to turn LTO support on without
resorting to `LDFLAGS` hacks or similar.