### PR TITLE
fix atom alias information in LTO linking

### DIFF
--- a/cctools/ld64/src/ld/ld.hpp
+++ b/cctools/ld64/src/ld/ld.hpp
@@ -1141,6 +1141,7 @@ public:
 													_dontDeadStrip = a._dontDeadStrip;
 													_dontDeadStripIfRefLive = a._dontDeadStripIfRefLive;
 													_thumb = a._thumb;
+													_alias = a._alias;
 													_autoHide = a._autoHide;
 													_contentType = a._contentType;
 													_symbolTableInclusion = a._symbolTableInclusion;


### PR DESCRIPTION
When performing LTO, `ld64` reads in any LLVM bitcode files, creates
atoms for them, and compiles the bitcode files to their corresponding
in-memory Mach-O files.  These Mach-O files are then
loaded (lto_file.cpp:Parser::loadMachO), and information from the atoms
in the Mach-O files is then synced to the corresponding atoms from the
LLVM bitcode files.

However, the underlying function (ld.hpp:Atom::setAttributesFromAtom)
fails to copy over the alias bit from the Mach-O symbol.  This omission
means that the original LLVM atom is not correctly marked as an alias
and therefore not correctly sorted prior to the symbol it is an alias
for (order.cpp:Layout::Comparer::operator()).  The end result is that
the alias symbol winds up pointing at a different symbol, with
predictably disastrous consequences when the aliased symbol is called.

This problem has been observed when performing cross-language LTO with
Firefox.  See also
https://bugzilla.mozilla.org/show_bug.cgi?id=1486042#c92 for more
details.

The fix is simple: we need to copy the alias bit over, just like other
fields.