### PR TITLE
Fix the logic for the default fallback sdk version in ld64

### DIFF
--- a/cctools/ld64/src/ld/Options.cpp
+++ b/cctools/ld64/src/ld/Options.cpp
@@ -5380,14 +5380,12 @@ void Options::reconfigureDefaults()
 			char kernVersStr[100];
 			size_t strlen = sizeof(kernVersStr);
 			if ( sysctl(mib, 2, kernVersStr, &strlen, NULL, 0) != -1 ) {
-#else
-				const char *kernVersStr = "10.5"; // ld64-port: claim we are on 10.5
-#endif
 				uint32_t kernVers = parseVersionNumber32(kernVersStr);
 				int minor = (kernVers >> 16) - 4;  // kernel major version is 4 ahead of x in 10.
 				fPlatforms.updateSDKVersion(ld::Platform::macOS, (0x000A0000 + (minor << 8)));
-#ifdef __APPLE__ // ld64-port
 			}
+#else
+			fPlatforms.updateSDKVersion(ld::Platform::macOS, parseVersionNumber32("10.6")); // ld64-port: claim we are on 10.6
 #endif
 		}
 	}


### PR DESCRIPTION
The apple case for the default uses sysctl to get the kernel
version, which is a version number like 18.7.0, where the major
version, minus 4, is used for setting the minor version of
the macOS version number, translating 18.7.0 into 10.14.

The previous ld64-port specific case of trying to hardcode 10.5,
just ends up parsed as kernel version 10, i.e. 10.6, regardless of
which version the default string is set to.

Instead of passing the cctools/ld64-port specific default to the
kernel version parsing logic, just set the result of
parseVersionNumber32 as the version number.