### PR TITLE
Fix conflict of variable/macro name PC for sparc

### DIFF
--- a/cctools/include/architecture/sparc/reg.h
+++ b/cctools/include/architecture/sparc/reg.h
@@ -40,7 +40,7 @@
  * Usage is u.u_ar0[XX].
  */
 #define	PSR	(0)
-#define	PC	(1)
+#define	SPARC_PC	(1)
 #define	nPC	(2)
 #define	SPARC_Y	(3)
 #define	G1	(4)


### PR DESCRIPTION
The deinition of macro name PC is pretty unlucky, as within llvm at many places this name is used as argument name ... so renaming it to a less conflicting name.