### PR TITLE
Fix lto detection with recent Ubuntu llvm releases 

### DIFF
--- a/cctools/m4/llvm.m4
+++ b/cctools/m4/llvm.m4
@@ -14,12 +14,16 @@ AC_DEFUN([CHECK_LLVM],
       if test "x$LLVM_CONFIG" = "xno"; then
           AC_PATH_PROGS(LLVM_CONFIG,
               [llvm-config                                              \
-               llvm-config-9.0 llvm-config-8.0                          \
-               llvm-config-7.0 llvm-config-6.0                          \
-               llvm-config-5.0 llvm-config-4.0                          \
+               llvm-config-11.0 llvm-config-11                          \
+               llvm-config-10.0 llvm-config-10                          \
+               llvm-config-9.0 llvm-config-9                            \
+               llvm-config-8.0 llvm-config-8                            \
+               llvm-config-7.0 llvm-config-7                            \
+               llvm-config-6.0 llvm-config-5.0 llvm-config-4.0          \
                llvm-config-3.9 llvm-config-3.8 llvm-config-3.7          \
                llvm-config-3.6 llvm-config-3.5 llvm-config-3.4          \
                llvm-config-3.3 llvm-config-3.2 llvm-config-3.1          \
+               llvm-config110 llvm-config100                            \
                llvm-config90 llvm-config80                              \
                llvm-config70 llvm-config60                              \
                llvm-config50 llvm-config40                              \


### PR DESCRIPTION
Ubuntu ships llvm-config-10. llvm-config-10.0 added as well just in case.

llvm-config-100 makes very little sense so don't bother.