### PR TITLE
docs: fix simple typo, widith -> width

### DIFF
--- a/cctools/include/llvm-c/Disassembler.h
+++ b/cctools/include/llvm-c/Disassembler.h
@@ -38,7 +38,7 @@ typedef void *LLVMDisasmContextRef;
  * is at the PC parameter.  For some instruction sets, there can be more than
  * one operand with symbolic information.  To determine the symbolic operand
  * information for each operand, the bytes for the specific operand in the
- * instruction are specified by the Offset parameter and its byte widith is the
+ * instruction are specified by the Offset parameter and its byte width is the
  * size parameter.  For instructions sets with fixed widths and one symbolic
  * operand per instruction, the Offset parameter will be zero and Size parameter
  * will be the instruction width.  The information is returned in TagBuf and is 


### PR DESCRIPTION
There is a small typo in cctools/include/llvm-c/Disassembler.h.

Should read `width` rather than `widith`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md