### PR TITLE
Fix tarflags: content isn't compressed

### DIFF
--- a/usage_examples/ios_toolchain/build.sh
+++ b/usage_examples/ios_toolchain/build.sh
@@ -30,7 +30,7 @@ function verbose_cmd
 function extract()
 {
     echo "extracting $(basename $1) ..."
-    local tarflags="xzf"
+    local tarflags="xf"
 
     case $1 in
         *.tar.xz|*.txz)


### PR DESCRIPTION
Latest commit introduced a superfluous z to tar arguments implying that content passed to tar is gzipped.
This is not the case as a decompressor is used to pipe data to tar.