### PR TITLE
Turn off outputIsMappableFile when building to osx-arm64

### DIFF
--- a/cctools/ld64/src/ld/OutputFile.cpp
+++ b/cctools/ld64/src/ld/OutputFile.cpp
@@ -3805,7 +3805,7 @@ void OutputFile::writeOutputFile(ld::Internal& state)
 			// <rdar://problem/12264302> Don't use mmap on non-hfs volumes
 #ifdef __APPLE__ // ld64-port
 			struct statfs fsInfo;
-			if ( statfs(_options.outputFilePath(), &fsInfo) != -1 ) {
+            if ( (_options.architecture() != CPU_TYPE_ARM64) && (statfs(_options.outputFilePath(), &fsInfo) != -1) ) {
 				if ( (strcmp(fsInfo.f_fstypename, "hfs") == 0) || (strcmp(fsInfo.f_fstypename, "apfs") == 0) ) {
 					(void)unlink(_options.outputFilePath());
 					outputIsMappableFile = true;
@@ -3835,7 +3835,7 @@ void OutputFile::writeOutputFile(ld::Internal& state)
 			end[1] = '\0';
 #ifdef __APPLE__ // ld64-port
 			struct statfs fsInfo;
-			if ( statfs(dirPath, &fsInfo) != -1 ) {
+            if ( (_options.architecture() != CPU_TYPE_ARM64) && (statfs(dirPath, &fsInfo) != -1) ) {
 				if ( (strcmp(fsInfo.f_fstypename, "hfs") == 0) || (strcmp(fsInfo.f_fstypename, "apfs") == 0) ) {
 					outputIsMappableFile = true;
 				}


### PR DESCRIPTION
This fixes #117.  

Further investigation shows that with the newest version of cctools-port + sigtool for signing then whenever the `outputIsMappableFile=true` which triggers `wholeBuffer = (uint8_t *)mmap(NULL, _fileSize, PROT_WRITE|PROT_READ, MAP_SHARED, fd, 0);` then the output binary will not work on M1 macs.  This can be triggered when either (a) the file already exists, or (b) the path is explicitly specified (relative or absolute).  I'm not sure why the `mmap` option is necessary, and everything appears to run fine turning it off (and it is off in regular usage when you target a new file without a path specified!).  