### PR TITLE
ld64: Swap LTO_RPATH to LTO_LIB - Fixes LTO on macOS

### DIFF
--- a/cctools/ld64/src/ld/Makefile.am
+++ b/cctools/ld64/src/ld/Makefile.am
@@ -7,7 +7,7 @@ ld_LDADD =  \
 	$(top_builddir)/ld64/src/ld/parsers/libParsers.la \
 	$(top_builddir)/ld64/src/ld/passes/libPasses.la \
 	$(UUID_LIB) \
-	$(LTO_RPATH) \
+	$(LTO_LIB) \
 	$(XAR_LIB) \
 	$(DL_LIB) \
 	$(TAPI_LIB) \

--- a/cctools/ld64/src/ld/Makefile.in
+++ b/cctools/ld64/src/ld/Makefile.in
@@ -407,7 +407,7 @@ ld_LDADD = \
 	$(top_builddir)/ld64/src/ld/parsers/libParsers.la \
 	$(top_builddir)/ld64/src/ld/passes/libPasses.la \
 	$(UUID_LIB) \
-	$(LTO_RPATH) \
+	$(LTO_LIB) \
 	$(XAR_LIB) \
 	$(DL_LIB) \
 	$(TAPI_LIB) \


### PR DESCRIPTION
Fixes LTO linking on macOS this follows what's done with other libraries in ld_LDADD section

Closes #120 