### PR TITLE
fix can't rename file

### DIFF
--- a/cctools/libstuff/ofile.c
+++ b/cctools/libstuff/ofile.c
@@ -1497,6 +1497,7 @@ struct ofile *ofile)
 			      "%s", ofile->file_name);
 	    }
 	}
+	munmap(ofile->file_addr, ofile->file_size);
 	if(ofile->file_name != NULL)
 	    free(ofile->file_name);
 	if(ofile->arch_flag.name != NULL)


### PR DESCRIPTION
rename() will fail at least on ranlib (libtool.c) when used on non-local filesystems because the memory map was not released