### PR TITLE
don't try to include __assert for NDEBUG builds

### DIFF
--- a/cctools/ld64/src/3rd/helper.c
+++ b/cctools/ld64/src/3rd/helper.c
@@ -37,6 +37,7 @@ const char ldVersionString[] = "@(#)PROGRAM:ld  PROJECT:ld64-" STRINGIFY(LD64_VE
 
 void __assert_rtn(const char *func, const char *file, int line, const char *msg)
 {
+#ifndef NDEBUG
 #if defined(__FreeBSD__) || defined(__DragonFly__)
     __assert(msg, file, line, func);
 #elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__CYGWIN__)
@@ -48,6 +49,7 @@ void __assert_rtn(const char *func, const char *file, int line, const char *msg)
     fflush(NULL);
     abort();
 #endif /* __FreeBSD__ */
+#endif /* NDEBUG */
 }
 
 int _NSGetExecutablePath(char *epath, unsigned int *size)


### PR DESCRIPTION
Even though `cctools/ld64/src/3rd/helper.c` correctly does `#include <assert.h>`, that header is [basically empty](https://github.com/bminor/glibc/blob/glibc-2.12/assert/assert.h#L50-L83) when `NDEBUG` is defined.

On clang 16, this causes a compilation error because it now got [stricter](https://github.com/llvm/llvm-project/blob/release/16.x/clang/docs/ReleaseNotes.rst) about implicit function declarations:
> The ``-Wimplicit-function-declaration`` and ``-Wimplicit-int`` warnings now default to an error in C99, C11, and C17. As of C2x, support for implicit function declarations and implicit int has been removed, and the warning options will have no effect. Specifying ``-Wimplicit-int`` in C89 mode will now issue warnings instead of being a noop.

In other words, `__assert_rtn` should not try to call `__assert` in the case of `NDEBUG` being defined. Add an `#ifndef` guard around the body of the function to achieve this.