### PR TITLE
Make builds more reproducible with `SOURCE_DATE_EPOCH`

### DIFF
--- a/cctools/ar/archive.c
+++ b/cctools/ar/archive.c
@@ -331,11 +331,15 @@ put_arobj(cfp, sb)
 		 * places that write archives to allow testing and comparing
 		 * things for exact binary equality.
 		 */
-		if (getenv("ZERO_AR_DATE") == NULL)
+		if (getenv("ZERO_AR_DATE") != NULL) {
+			tv_sec = (long int)0;
+		} else if (getenv("SOURCE_DATE_EPOCH") != NULL) {
+			/* If the SOURCE_DATE_EPOCH variable is set to something, use it for deterministic timestamps */
+			tv_sec = (long int)strtoll(getenv("SOURCE_DATE_EPOCH"), NULL, 10);
+		} else {
 			/* cctools-port: sb->st_mtimespec.tv_sec -> sb->st_mtime */
 			tv_sec = (long int)sb->st_mtime;
-		else
-			tv_sec = (long int)0;
+		}
 
 		/*
 		 * If not truncating names and the name is too long or contains


### PR DESCRIPTION
In order to support "reproducible builds" for static libraries it would be great if `ar` supports `SOURCE_DATE_EPOCH` as an alternate means to use a timestamp (vs. looking at the `stat` output for a given file).

This is further documented here: https://reproducible-builds.org/docs/source-date-epoch/