### PR TITLE
fix `as` when ccache is installed

### DIFF
--- a/cctools/as/driver.c
+++ b/cctools/as/driver.c
@@ -320,7 +320,8 @@ char **envp)
 	    }
 	    new_argv = allocate((argc + 10) * sizeof(char *)); /* cctools-port:
 								  + 8 -> + 10 */
-	    new_argv[0] = as;
+	    /* new_argv[0] = as; */
+	    new_argv[0] = "clang"; /* cctools-port: fix ccache */
 	    j = 1;
 	    /*
 	     * Add "-x assembler" in case the input does not end in .s this must


### PR DESCRIPTION
fixes https://github.com/tpoechtrager/cctools-port/issues/138

argv0 must be "clang" for ccache to run the compiler

https://github.com/tpoechtrager/cctools-port/pull/139 but rebased on the new version