### PR TITLE
better otool wrapper

### DIFF
--- a/cctools/otool-wrapper/main.c
+++ b/cctools/otool-wrapper/main.c
@@ -3,21 +3,20 @@
 #include <unistd.h>
 
 int main(int argc, char *argv[]) {
-    // Assuming llvm-otool binary is in the PATH, otherwise provide the full path
-    char *binaryPath = "llvm-otool";
-
     // Prepare the arguments array for execvp
     char *new_argv[argc + 1]; // +1 for the NULL terminator
-    new_argv[0] = binaryPath;
+    new_argv[0] = "otool";
     for (int i = 1; i < argc; ++i) {
         new_argv[i] = argv[i];
     }
     new_argv[argc] = NULL; // NULL-terminate the array
 
-    // Replace the current process with llvm-otool binary
-    execvp(binaryPath, new_argv);
+    // Replace the current process with otool
+    execvp("otool", new_argv);
+    // execvp only returns if an error occurred, try again with llvm-otool
+    execvp("llvm-otool", new_argv);
 
-    // execvp only returns if an error occurred
-    fprintf(stderr, "Could not execute llvm-otool; llvm-otool comes with llvm 13 onwards\n");
+    // Neither otool nor llvm-otool could be executed, print an error message and exit
+    fprintf(stderr, "Could not execute otool or llvm-otool; llvm-otool comes with llvm 13 onwards\n");
     return EXIT_FAILURE;
 }


### PR DESCRIPTION
The main change is that it tries `otool` first, then `llvm-otool` if that fails.  This fixes the otool wrapper on macOS, where `llvm-otool` isn't in PATH but `otool` is.