### PR TITLE
Remove unused broken clone function

### DIFF
--- a/cctools/ld64/src/ld/code-sign-blobs/blob.h
+++ b/cctools/ld64/src/ld/code-sign-blobs/blob.h
@@ -181,9 +181,6 @@ public:
 		return NULL;
 	}
 	
-	BlobType *clone() const
-	{ assert(validateBlob()); return specific(this->BlobCore::clone());	}
-
 	static BlobType *readBlob(int fd)
 	{ return specific(BlobCore::readBlob(fd, _magic, sizeof(BlobType), 0), true); }
 


### PR DESCRIPTION
The base class doesn't have a clone member function, so the code was never valid. As it was unused, that didn't cause problems until clang caught this earlier than instantiation in
https://github.com/llvm/llvm-project/pull/84050