### PR TITLE
Restore using __builtin_available for macos (redux)

### DIFF
--- a/cctools/libstuff/writeout.c
+++ b/cctools/libstuff/writeout.c
@@ -145,27 +145,27 @@ uint32_t *throttle)
 
 #ifndef __OPENSTEP__
 	/* cctools-port: replaced __builtin_available */
-#if 0
+#ifdef __APPLE__
 	if (__builtin_available(macOS 10.12, *)) {
-#endif /* 0 */
+#endif /* __APPLE__ */
 #ifdef HAVE_CLOCK_GETTIME
 	    if (clock_gettime(CLOCK_REALTIME, &toc_timespec)) {
 		system_error("clock_gettime failed");
 		return;
 	    }
 #endif /* HAVE_CLOCK_GETTIME */
-#if 0
+#ifdef __APPLE__
 	} else {
-#endif /* 0 */
+#endif /* __APPLE__ */
 #ifndef HAVE_CLOCK_GETTIME
 	    if (gettimeofday(&toc_timeval, NULL)) {
 		system_error("gettimeofday failed");
 		return;
 	    }
 #endif /* !HAVE_CLOCK_GETTIME */
-#if 0
+#ifdef __APPLE__
 	}
-#endif /* 0 */
+#endif /* __APPLE__ */
 #else
 	/*
 	 * The environment variable ZERO_AR_DATE is used here and other

--- a/cctools/misc/libtool.c
+++ b/cctools/misc/libtool.c
@@ -1382,9 +1382,9 @@ char **envp)
 	if (cmd_flags.D == FALSE && zero_ar_date == FALSE) {
 #ifndef __OPENSTEP__
 		/* cctools-port: replaced __builtin_available */
-#if 0
+#ifdef __APPLE__
 	    if (__builtin_available(macOS 10.12, *)) {
-#endif /* 0*/ 
+#endif /* __APPLE__ */
 #ifdef HAVE_CLOCK_GETTIME
 		if (clock_gettime(CLOCK_REALTIME, &toc_timespec)) {
 		    system_fatal("clock_gettime failed");
@@ -1392,9 +1392,9 @@ char **envp)
 		}
 		toc_time = toc_timespec.tv_sec;
 #endif /* HAVE_CLOCK_GETTIME */
-#if 0
+#ifdef __APPLE__
 	    } else {
-#endif /* 0 */
+#endif /* __APPLE__ */
 #ifndef HAVE_CLOCK_GETTIME
 		if (gettimeofday(&toc_timeval, NULL)) {
 		    system_fatal("gettimeofday failed");
@@ -1402,9 +1402,9 @@ char **envp)
 		}
 		toc_time = toc_timeval.tv_sec;
 #endif /* !HAVE_CLOCK_GETTIME */
-#if 0
+#ifdef __APPLE__
 	    }
-#endif /* 0 */
+#endif /* __APPLE__ */
 #else
 	    toc_time = time(NULL);
 #endif /* !defined(__OPENSTEP__) */


### PR DESCRIPTION
This is a rebase of #116, which initially got the logic inverted. This was fixed on conda-forge side in https://github.com/conda-forge/cctools-and-ld64-feedstock/commit/167d022955b3055fd98e81613b48050cc3bbec04, and we've been shipping that patch ever since.

Closes #116