### PR TITLE
fix glibc headers

### DIFF
--- a/cctools/ld64/src/ld/libcodedirectory.c
+++ b/cctools/ld64/src/ld/libcodedirectory.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <errno.h>
+#include <fcntl.h>
 #include "3rd/helper.h" // ld64-port
 
 #include <arpa/inet.h>


### PR DESCRIPTION
Something about the glibc headers makes it so that if things are included in the wrong order, you can get errors like the following:

```
In file included from work/cctools/ld64/src/ld/libcodedirectory.c:42:
In file included from $HOST/include/dispatch/dispatch.h:44:
In file included from work/cctools/include/foreign/fcntl.h:1:
In file included from $BUILD/x86_64-conda-linux-gnu/sysroot/usr/include/fcntl.h:77:
$BUILD/x86_64-conda-linux-gnu/sysroot/usr/include/bits/stat.h:106:31: error: expected member name or ';' after declaration specifiers
  106 |     __syscall_slong_t __unused[3];
```

We can avoid these issues by making sure that certain headers are included sufficiently early.

(This is from work by @pkgw in https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/70; the error still exists in the newest version, see [here](https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/75#issuecomment-2333213970))