### PR TITLE
[🍒] Remove unused broken clone function

### DIFF
--- a/cctools/ld64/src/ld/code-sign-blobs/blob.h
+++ b/cctools/ld64/src/ld/code-sign-blobs/blob.h
@@ -181,9 +181,6 @@ public:
 		return NULL;
 	}
 	
-	BlobType *clone() const
-	{ assert(validateBlob()); return specific(this->BlobCore::clone());	}
-
 	static BlobType *readBlob(int fd)
 	{ return specific(BlobCore::readBlob(fd, _magic, sizeof(BlobType), 0), true); }
 


### PR DESCRIPTION
Somehow https://github.com/tpoechtrager/cctools-port/commit/69160658f88ebc582f8d9155ecea1575696f8067 got dropped between 1009.2-ld64-907 and 1010.6-ld64-951.9, meaning that the latter fails on newer clang with
```
$SRC_DIR/cctools/ld64/src/ld/parsers/../code-sign-blobs/blob.h:185:60: error: no member named 'clone' in 'Security::BlobCore'
  185 |         { assert(validateBlob()); return specific(this->BlobCore::clone());     }
      |                                                         ~~~~~~~~~~^
```

Cherry-pick that commit to the branch to fix.