### PR TITLE
fix 877.8-ld64-253.9-ppc

### DIFF
--- a/cctools/include/foreign/sys/sysctl.h
+++ b/cctools/include/foreign/sys/sysctl.h
@@ -1,6 +1,4 @@
-#ifndef __CYGWIN__
-#include_next <sys/sysctl.h>
-#else
+#if defined(__CYGWIN__)
 #ifndef __SYSCTL_H__
 #define __SYSCTL_H__
 
@@ -19,4 +17,8 @@ int sysctl(const int *name, u_int namelen, void *oldp,	size_t *oldlenp,
     return -1;
 }
 #endif /* __SYSCTL_H__ */
-#endif /* ! __CYGWIN__ */
+#elif defined(__linux__)
+#include <linux/sysctl.h>
+#else
+#include_next <sys/sysctl.h>
+#endif

--- a/cctools/ld64/src/abstraction/MachOFileAbstraction.hpp
+++ b/cctools/ld64/src/abstraction/MachOFileAbstraction.hpp
@@ -543,7 +543,7 @@ static const ArchInfo archInfoArray[] = {
 	#define SUPPORT_ARCH_arm_any 1
 #endif
 #if SUPPORT_ARCH_armv6
-	{ "armv6", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V6,     "armv6-",   "", true,  false },
+	{ "armv6", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V6,     "armv6-",   "armv6k-", true,  false }, /* cctools-port: add armv6k- */
 	#define SUPPORT_ARCH_arm_any 1
 #endif
 #if SUPPORT_ARCH_armv7

--- a/cctools/ld64/src/ld/code-sign-blobs/blob.h
+++ b/cctools/ld64/src/ld/code-sign-blobs/blob.h
@@ -181,9 +181,6 @@ public:
 		return NULL;
 	}
 	
-	BlobType *clone() const
-	{ assert(validateBlob()); return specific(this->BlobCore::clone());	}
-
 	static BlobType *readBlob(int fd)
 	{ return specific(BlobCore::readBlob(fd, _magic, sizeof(BlobType), 0), true); }
 

--- a/cctools/libstuff/lto.c
+++ b/cctools/libstuff/lto.c
@@ -249,6 +249,7 @@ char *target_triple)
 	    arch_flag->cpusubtype = CPU_SUBTYPE_ARM_V5TEJ;
 	}
 	else if(strncmp(target_triple, "armv6", n) == 0 ||
+	        strncmp(target_triple, "armv6k", n) == 0 || /* cctools-port */
 	        strncmp(target_triple, "thumbv6", n) == 0){
 	    arch_flag->cputype = CPU_TYPE_ARM;
 	    arch_flag->cpusubtype = CPU_SUBTYPE_ARM_V6;

--- a/cctools/otool/arm64_disasm.c
+++ b/cctools/otool/arm64_disasm.c
@@ -15,6 +15,8 @@
 #include "arm64_disasm.h"
 #include "cxa_demangle.h"
 
+#define dis_info arm64_dis_info
+
 struct disassemble_info {
   /* otool(1) specific stuff */
   enum bool verbose;

--- a/cctools/otool/arm_disasm.c
+++ b/cctools/otool/arm_disasm.c
@@ -41,6 +41,8 @@
 #include "arm_disasm.h"
 #include "cxa_demangle.h"
 
+#define dis_info arm_dis_info
+
 /* Used by otool(1) to stay or switch out of thumb mode */
 enum bool in_thumb = FALSE;
 

--- a/cctools/otool/i386_disasm.c
+++ b/cctools/otool/i386_disasm.c
@@ -71,6 +71,8 @@ WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "i386_disasm.h"
 #include "cxa_demangle.h"
 
+#define dis_info i386_dis_info
+
 #define MAX_MNEMONIC	16	/* Maximum number of chars per mnemonic, plus a byte for '\0' */
 #define MAX_RESULT	14	/* Maximum number of char in a register */
 				/*  result expression "(%ebx,%ecx,8)" */


### PR DESCRIPTION
This backports the fixes with armv6 LTO and the broken clone function to 877.8-ld64-253.9-ppc, the last branch to support PPC.  The clone function fix is required for ld64 to compile.