### PR TITLE
omit duplicate rpaths

### DIFF
--- a/cctools/ld64/src/ld/Options.cpp
+++ b/cctools/ld64/src/ld/Options.cpp
@@ -46,6 +46,7 @@
 #include <mach-o/dyld_priv.h>
 
 #include <algorithm>
+#include <set>
 #include <vector>
 #include <map>
 #include <sstream>
@@ -2585,6 +2586,9 @@ void Options::parse(int argc, const char* argv[])
 	// reduce re-allocations
 	fInputFiles.reserve(32);
 
+	// ignore duplicate rpaths
+	std::set<std::string> seen_rpaths;
+
 	// pass two parse all other options
 	for(int i=1; i < argc; ++i) {
 		const char* arg = argv[i];
@@ -3697,7 +3701,13 @@ void Options::parse(int argc, const char* argv[])
 			}
 			else if ( strcmp(arg, "-rpath") == 0 ) {
 				const char* path = checkForNullArgument(arg, argv[++i]);
+				const std::string rpath_str = path;
+				if (seen_rpaths.count(rpath_str)) {
+					fprintf(stderr, "ld: warning: duplicate -rpath '%s' ignored\n", rpath_str.c_str());
+				} else {
 				fRPaths.push_back(path);
+				seen_rpaths.insert(rpath_str);
+				}
 			}
 			else if ( strcmp(arg, "-read_only_stubs") == 0 ) {
 				fReadOnlyx86Stubs = true;


### PR DESCRIPTION
omit duplicates and warn, matching ld-prime behavior starting with xcode 15.

The warning is identical to what's emitted by Apple's ld-prime in the same situation:

```
ld: warning: duplicate -rpath '$PREFIX/lib' ignored
```

Duplicate LC_RPATH entries result in binaries failing to load starting in macOS 15.4:

> OSError: dlopen($PREFIX/lib/libgfortran.5.dylib, 0x0006): tried: '$PREFIX/lib/libgfortran.5.dylib' (duplicate LC_RPATH '@loader_path')

Error is raised by [dyld here](https://github.com/apple-oss-distributions/dyld/blob/fba6732ffad1c798f31b2129eee4e073e6ae07dc/mach_o/Header.cpp#L722).