### PR TITLE
as: Allow overriding `clang` executable name via `CCTOOLS_CLANG_AS_EXECUTABLE`

### DIFF
--- a/cctools/as/driver.c
+++ b/cctools/as/driver.c
@@ -307,10 +307,12 @@ char **envp)
 	    as = makestr(prefix, CLANG, NULL);
 #endif
 	    /* cctools-port start */
+		char *clang_exe = getenv("CCTOOLS_CLANG_AS_EXECUTABLE");
+		clang_exe = clang_exe ? clang_exe : "clang";
 #ifndef __APPLE__
 	    char *target_triple = getenv("CCTOOLS_CLANG_AS_TARGET_TRIPLE");
 #endif /* ! __APPLE__ */
-	    as = find_executable("clang");
+	    as = find_executable(clang_exe);
 	    /* cctools-port end */
 	    if(!as || access(as, F_OK) != 0){ /* cctools-port: added  !as || */
 		printf("%s: assembler (%s) not installed\n", progname,


### PR DESCRIPTION
This aids in toolchain deployments where clang may not be named simply `clang`, but instead something like `x86_64-apple-darwin20-clang`.  While `clang` is a cross-compiler that can change its targets via `-target` flags and such, it's not unheard of to have wrapper scripts that embed the targeting arguments within themselves, in which case they are invoked via different base names.