### PR TITLE
Support building with old macOS SDKs that provide the TargetConditionals.h header but not the __API_DEPRICATED macro

### DIFF
--- a/cctools/include/mach-o/arch.h
+++ b/cctools/include/mach-o/arch.h
@@ -38,8 +38,13 @@
 		#include <TargetConditionals.h>
 
 		#ifndef __CCTOOLS_DEPRECATED
-				#define __CCTOOLS_DEPRECATED            __API_DEPRECATED("No longer supported", macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
-				#define __CCTOOLS_DEPRECATED_MSG(_msg)  __API_DEPRECATED_WITH_REPLACEMENT(_msg, macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
+				#ifdef __API_DEPRECATED
+						#define __CCTOOLS_DEPRECATED            __API_DEPRECATED("No longer supported", macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
+						#define __CCTOOLS_DEPRECATED_MSG(_msg)  __API_DEPRECATED_WITH_REPLACEMENT(_msg, macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
+				#else
+						#define __CCTOOLS_DEPRECATED
+						#define __CCTOOLS_DEPRECATED_MSG(_msg)
+				#endif
 		#endif
 #else
 		#ifndef __CCTOOLS_DEPRECATED

--- a/cctools/include/mach-o/getsect.h
+++ b/cctools/include/mach-o/getsect.h
@@ -28,18 +28,24 @@
 #include <Availability.h>
 
 #if __has_include(<TargetConditionals.h>) /* cctools-port */
-    #include <TargetConditionals.h>
+		#include <TargetConditionals.h>
 
-    #ifndef __CCTOOLS_DEPRECATED
-        #define __CCTOOLS_DEPRECATED            __API_DEPRECATED("No longer supported", macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
-        #define __CCTOOLS_DEPRECATED_MSG(_msg)  __API_DEPRECATED_WITH_REPLACEMENT(_msg, macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
-    #endif
+		#ifndef __CCTOOLS_DEPRECATED
+				#ifdef __API_DEPRECATED
+						#define __CCTOOLS_DEPRECATED            __API_DEPRECATED("No longer supported", macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
+						#define __CCTOOLS_DEPRECATED_MSG(_msg)  __API_DEPRECATED_WITH_REPLACEMENT(_msg, macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
+				#else
+						#define __CCTOOLS_DEPRECATED
+						#define __CCTOOLS_DEPRECATED_MSG(_msg)
+				#endif
+		#endif
 #else
-    #ifndef __CCTOOLS_DEPRECATED
-        #define __CCTOOLS_DEPRECATED
-        #define __CCTOOLS_DEPRECATED_MSG(_msg)
-    #endif
+		#ifndef __CCTOOLS_DEPRECATED
+				#define __CCTOOLS_DEPRECATED
+				#define __CCTOOLS_DEPRECATED_MSG(_msg)
+		#endif
 #endif
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/cctools/include/mach-o/swap.h
+++ b/cctools/include/mach-o/swap.h
@@ -33,17 +33,22 @@
 #include <Availability.h>
 
 #if __has_include(<TargetConditionals.h>) /* cctools-port */
-    #include <TargetConditionals.h>
+		#include <TargetConditionals.h>
 
-    #ifndef __CCTOOLS_DEPRECATED
-        #define __CCTOOLS_DEPRECATED            __API_DEPRECATED("No longer supported", macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
-        #define __CCTOOLS_DEPRECATED_MSG(_msg)  __API_DEPRECATED_WITH_REPLACEMENT(_msg, macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
-    #endif
+		#ifndef __CCTOOLS_DEPRECATED
+				#ifdef __API_DEPRECATED
+						#define __CCTOOLS_DEPRECATED            __API_DEPRECATED("No longer supported", macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
+						#define __CCTOOLS_DEPRECATED_MSG(_msg)  __API_DEPRECATED_WITH_REPLACEMENT(_msg, macos(10.0, 13.0), ios(1.0, 16.0), watchos(1.0, 8.0), tvos(1.0, 16.0))
+				#else
+						#define __CCTOOLS_DEPRECATED
+						#define __CCTOOLS_DEPRECATED_MSG(_msg)
+				#endif
+		#endif
 #else
-    #ifndef __CCTOOLS_DEPRECATED
-        #define __CCTOOLS_DEPRECATED
-        #define __CCTOOLS_DEPRECATED_MSG(_msg)
-    #endif
+		#ifndef __CCTOOLS_DEPRECATED
+				#define __CCTOOLS_DEPRECATED
+				#define __CCTOOLS_DEPRECATED_MSG(_msg)
+		#endif
 #endif
 
 #ifdef __cplusplus

--- a/usage_examples/ios_toolchain/wrapper.c
+++ b/usage_examples/ios_toolchain/wrapper.c
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
     }
 
     args[i++] = osvermin;
-    args[i++] = "-mlinker-version=951.9";
+    args[i++] = "-mlinker-version=954.16";
     args[i++] = "-Wl,-adhoc_codesign";
     args[i++] = "-Wno-unused-command-line-argument";
 


### PR DESCRIPTION
As a drive-by change, also update the linker version passed to clang in the iOS toolchain wrapper.c file.