### PR TITLE
add ld man page

### DIFF
--- a/cctools/ld64/doc/man/Makefile.am
+++ b/cctools/ld64/doc/man/Makefile.am
@@ -1,4 +1,5 @@
 dist_man_MANS =
 dist_man_MANS += man1/ld64.1
+dist_man_MANS += man1/ld.1
 dist_man_MANS += man1/ld-classic.1
 dist_man_MANS += man1/unwinddump.1

--- a/cctools/ld64/doc/man/Makefile.in
+++ b/cctools/ld64/doc/man/Makefile.in
@@ -310,7 +310,8 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-dist_man_MANS = man1/ld64.1 man1/ld-classic.1 man1/unwinddump.1
+dist_man_MANS = man1/ld64.1 man1/ld.1 man1/ld-classic.1 \
+	man1/unwinddump.1
 all: all-am
 
 .SUFFIXES:

--- a/cctools/ld64/doc/man/man1/ld.1
+++ b/cctools/ld64/doc/man/man1/ld.1
@@ -1,0 +1,1 @@
+.so man1/ld-classic.1


### PR DESCRIPTION
Since we install ld-classic as just ld, and since the new Apple linker is closed source, we should install an ld alias man page for ld-classic. 