### PR TITLE
use fcntl.h instead of sys/fcntl.h

### DIFF
--- a/cctools/ld64/src/ld/parsers/lto_file.cpp
+++ b/cctools/ld64/src/ld/parsers/lto_file.cpp
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <sys/param.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <errno.h>


### PR DESCRIPTION
this fixes warns on musl