### PR TITLE
remove some leftover dead code

### DIFF
--- a/cctools/ld64/src/ld/Options.cpp
+++ b/cctools/ld64/src/ld/Options.cpp
@@ -4332,9 +4332,6 @@ void Options::parse(int argc, const char* argv[])
 			else if (strcmp(arg, "-no_adhoc_codesign") == 0) {
 				fAdHocSignForceOff = true;
 			}
-			else if (strcmp(arg, "-no_adhoc_codesign") == 0) { // ld64-port
-				fAdHocSign = false;
-			}
 			else if (strcmp(arg, "-oso_prefix") == 0) {
 				const char* path = argv[++i];
 				if ( path == NULL )


### PR DESCRIPTION
Apple decided to upstream the `-no_adhoc_codesign` option a while ago, but the cctools-port code for it was never removed, this code will never be reached because it is an else after an identical strcmp