### PR TITLE
fix build on macos

### DIFF
--- a/cctools/ld64/src/mach_o/Error.cpp
+++ b/cctools/ld64/src/mach_o/Error.cpp
@@ -23,13 +23,11 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h> // ld64-port
 #include <string.h>
 #include <assert.h>
 //#include <uuid/uuid.h> // ld64-port: commented
 #include <errno.h>
-#if !defined(__APPLE__) && __has_include(<malloc.h>)
-#include <malloc.h> // ld64-port
-#endif
 //#include <TargetConditionals.h> // ld64-port: commented
 
 #include <mach/machine.h>


### PR DESCRIPTION
Build fails on newer macOS versions because free() is undeclared, also it looks like the malloc.h header is useless here so I removed it