### PR TITLE
Support iOS 1.x better

### DIFF
--- a/cctools/ld64/src/ld/Options.cpp
+++ b/cctools/ld64/src/ld/Options.cpp
@@ -6822,7 +6822,7 @@ void Options::checkIllegalOptionCombinations()
 
 	// can't use -rpath unless targeting 10.5 or later
 	if ( fRPaths.size() > 0 ) {
-		if ( !platforms().minOS(ld::version2008) )
+		if ( !platforms().minOS(ld::version2007Fall) )
 			throw "-rpath can only be used when targeting Mac OS X 10.5 or later";
 		switch ( fOutputKind ) {
 			case Options::kDynamicExecutable:

--- a/cctools/ld64/src/ld/ld.hpp
+++ b/cctools/ld64/src/ld/ld.hpp
@@ -223,6 +223,7 @@ static const PlatformVersion mac14_4		(Platform::macOS, 0x000E0400);
 static const PlatformVersion mac15_0		(Platform::macOS, 0x000F0000);
 static const PlatformVersion mac10_Future 	(Platform::macOS, 0x10000000);
 
+static const PlatformVersion iOS_1_0 		(Platform::iOS, 0x00010000);
 static const PlatformVersion iOS_2_0 		(Platform::iOS, 0x00020000);
 static const PlatformVersion iOS_3_1 		(Platform::iOS, 0x00030100);
 static const PlatformVersion iOS_4_2 		(Platform::iOS, 0x00040200);
@@ -304,7 +305,8 @@ static const PlatformSet simulatorPlatforms ( {
 
 //FIXME do we need to add simulatots to these?
 //FIXME Are the dates correct?
-static const VersionSet version2007		({mac10_4, iOS_2_0});
+static const VersionSet version2007		({mac10_4, iOS_1_0});
+static const VersionSet version2007Fall ({mac10_5, iOS_1_0});
 static const VersionSet version2008 	({mac10_5, iOS_2_0});
 static const VersionSet version2008Fall ({mac10_5, iOS_3_1});
 static const VersionSet version2009 	({mac10_6, iOS_3_1});


### PR DESCRIPTION
iOS 1.x dyld had support for rpath, but not LC_REEXPORT_DYLIB