### PR TITLE
remove deprecation warn

### DIFF
--- a/cctools/ld64/src/ld/Options.cpp
+++ b/cctools/ld64/src/ld/Options.cpp
@@ -3420,9 +3420,11 @@ void Options::parse(int argc, const char* argv[])
 						value = info->minimumOsVersion;
 						warning("changing %s minOS version from %s to %s", info->printName, versStr, getVersionString32(info->minimumOsVersion).c_str());
 					}
+#if 0 // ld64-port: addded #if 0
 					else {
 						warning("building for %s %s is deprecated", info->printName, versStr);
 					}
+#endif
 				}
 				if (fPlatforms.contains(info->platform)) {
 					std::string existingVersionStr = getVersionString32(fPlatforms.minOS(info->platform));


### PR DESCRIPTION
This shows if you do something like `-ios_version_min 2.0` instead of `-platform_version ios 2.0 2.0`, happens if the version is less than 7.0.  Doesn't serve a purpose.