### PR TITLE
fix building on legacy macos

### DIFF
--- a/cctools/ld64/src/ld/libcodedirectory.c
+++ b/cctools/ld64/src/ld/libcodedirectory.c
@@ -69,7 +69,7 @@
 #endif
 
 #define bl htonl
-#ifndef __APPLE__ // ld64-port
+#ifndef htonll // ld64-port
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define htonll __builtin_bswap64
 #else


### PR DESCRIPTION
Older macOS doesn't define htonll