### PR TITLE
Add missing BlobCore::clone() implementation

### DIFF
--- a/cctools/ld64/src/ld/code-sign-blobs/blob.cpp
+++ b/cctools/ld64/src/ld/code-sign-blobs/blob.cpp
@@ -52,6 +52,16 @@ const char *BlobCore::stringAt(Offset offset) const
 		return NULL;
 }
 
+//
+// Clone (deep copy) a blob
+//
+BlobCore *BlobCore::clone() const
+{
+	size_t len = this->length();
+	BlobCore *copy = (BlobCore *)malloc(len);
+	if (copy) memcpy(copy, this, len);
+	return copy;
+}
 
 //
 // Read a blob from a standard file stream.

--- a/cctools/ld64/src/ld/code-sign-blobs/blob.h
+++ b/cctools/ld64/src/ld/code-sign-blobs/blob.h
@@ -105,6 +105,8 @@ public:
 	char *stringAt(Offset offset);
 	const char *stringAt(Offset offset) const;
 
+	BlobCore *clone() const;
+
 	void *data()						{ return this; }
 	const void *data() const			{ return this; }
 	void length(size_t size)			{ mLength = size; }


### PR DESCRIPTION
## Problem

The `Blob<BlobType>` template class has a `clone()` method (line 184-185) that calls `this->BlobCore::clone()`, but the `BlobCore::clone()` method is **not declared** in `blob.h` nor **implemented** in `blob.cpp`. This causes a linker error when the method is actually invoked.

## Discovery

This issue was discovered when building osxcross with **RHEL 9.6 toolchain (GCC 14.2)**, which performs stricter linking checks than previous versions. The same code compiled successfully with RHEL 9.4 but fails with undefined symbol errors on RHEL 9.6:

```
undefined reference to BlobCore::clone() const
```

## Solution

This PR adds:
1. **Declaration** of `BlobCore::clone()` in `blob.h` (after `stringAt()` methods)
2. **Implementation** in `blob.cpp` that performs a deep copy

The implementation follows the same pattern as other BlobCore methods, using `malloc` and `memcpy` to create a proper deep copy of the blob:

```cpp
BlobCore *BlobCore::clone() const
{
    size_t len = this->length();
    BlobCore *copy = (BlobCore *)malloc(len);
    if (copy) memcpy(copy, this, len);
    return copy;
}
```

## Testing

- Tested with RHEL 9.6 / GCC 14.2 building osxcross cross-compiler toolchain
- Successfully links and executes without errors
- Backwards compatible with older toolchains

## Files Changed

- `cctools/ld64/src/ld/code-sign-blobs/blob.h`: Added method declaration
- `cctools/ld64/src/ld/code-sign-blobs/blob.cpp`: Added implementation

This has been a latent bug that newer compilers/linkers are now catching.