### PR TITLE
Copy llvm-c/Visibility.h and llvm/Config/llvm-config.h alongside lto.h (LLVM 23)

### DIFF
--- a/cctools/m4/llvm.m4
+++ b/cctools/m4/llvm.m4
@@ -68,6 +68,12 @@ AC_DEFUN([CHECK_LLVM],
               cp -f $LLVM_INCLUDE_DIR/llvm-c/ExternC.h `dirname ${0}`/include/llvm-c
             fi
 
+            if test -e $LLVM_INCLUDE_DIR/llvm-c/Visibility.h; then
+              cp -f $LLVM_INCLUDE_DIR/llvm-c/Visibility.h `dirname ${0}`/include/llvm-c
+              mkdir -p `dirname ${0}`/include/llvm/Config
+              cp -f $LLVM_INCLUDE_DIR/llvm/Config/llvm-config.h `dirname ${0}`/include/llvm/Config
+            fi
+
             LTO_DEF=-DLTO_SUPPORT
             LTO_LIB="-L${LLVM_LIB_DIR} -lLTO"
 


### PR DESCRIPTION
Since LLVM 23 (llvm/llvm-project commit 0e02ccdaf010), `llvm-c/lto.h` includes `llvm-c/Visibility.h`, which in turn includes `llvm/Config/llvm-config.h`. `CHECK_LLVM` in `cctools/m4/llvm.m4` deliberately copies `lto.h` and `ExternC.h` out of `$(llvm-config --includedir)` instead of adding that directory to the include path, so with LLVM 23 the libstuff build fails:

```
../include/llvm-c/lto.h:20:10: fatal error: 'llvm-c/Visibility.h' file not found
```

This copies the two new headers alongside the existing ones, guarded on `Visibility.h` existing so older LLVM releases are unaffected. `llvm-config.h` is a self-contained set of `#define`s.

Tested by building cctools-port against LLVM 22.1.8 (unchanged) and 23.1.0 (previously failing, now builds) in Firefox's CI.